### PR TITLE
Add BTC price analysis notebook

### DIFF
--- a/notebooks/btc_price_analysis.ipynb
+++ b/notebooks/btc_price_analysis.ipynb
@@ -1,0 +1,105 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# BTC Price Analysis\n",
+        "\n",
+        "This notebook demonstrates how to visualize the Bitcoin price, the Fear & Greed index, and the predicted price from our simple linear regression model."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import sys\n",
+        "from pathlib import Path\n",
+        "import polars as pl\n",
+        "import matplotlib.pyplot as plt\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Load processed data\n",
+        "data_path = Path(\"../data/processed/fear_and_greed_history_5min.parquet\")\n",
+        "df = pl.read_parquet(data_path).drop_nulls()\n",
+        "df = df.sort(\"date\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Import training helper\n",
+        "src_path = Path(\"../python_train/src\").resolve()\n",
+        "if str(src_path) not in sys.path:\n",
+        "    sys.path.insert(0, str(src_path))\n",
+        "from train import train_model\n",
+        "feature_cols = [\n",
+        "    \"open_actual_value\",\n",
+        "    \"open_bitcoin_price_usd\",\n",
+        "    \"high_bitcoin_price_usd\",\n",
+        "    \"low_bitcoin_price_usd\",\n",
+        "    \"avg_actual_value\",\n",
+        "]\n",
+        "model = train_model(df)\n",
+        "df = df.with_columns(pl.Series(\"predicted_price\", model.predict(df.select(feature_cols).to_numpy())))\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Plot actual vs predicted price and index\n",
+        "plt.figure(figsize=(14, 6))\n",
+        "plt.plot(df[\"date\"].to_list(), df[\"close_bitcoin_price_usd\"].to_list(), label=\"BTC Close\")\n",
+        "plt.plot(df[\"date\"].to_list(), df[\"predicted_price\"].to_list(), label=\"Predicted\", linestyle=\"--\")\n",
+        "plt.plot(df[\"date\"].to_list(), df[\"open_actual_value\"].to_list(), label=\"Fear & Greed\", alpha=0.5)\n",
+        "plt.legend()\n",
+        "plt.xlabel(\"Date\")\n",
+        "plt.ylabel(\"Value\")\n",
+        "plt.title(\"BTC Price vs Fear & Greed Index\")\n",
+        "plt.tight_layout()\n",
+        "plt.show()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Compute correlations\n",
+        "import numpy as np\n",
+        "cor_fg = np.corrcoef(df[\"open_actual_value\"].to_numpy(), df[\"close_bitcoin_price_usd\"].to_numpy())[0,1]\n",
+        "cor_pred = np.corrcoef(df[\"predicted_price\"].to_numpy(), df[\"close_bitcoin_price_usd\"].to_numpy())[0,1]\n",
+        "print(f\"Correlation (Fear & Greed vs BTC): {cor_fg:.3f}\")\n",
+        "print(f\"Correlation (Predicted vs BTC): {cor_pred:.3f}\")\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "pygments_lexer": "ipython3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add an example Data Science notebook for BTC price analysis
- include code that reuses the existing training module and plots price vs Fear & Greed index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857d7dbaef88326a12e2c20e83f3fa9