### PR TITLE
Fix push failure in train workflow

### DIFF
--- a/.github/workflows/train_model.yml
+++ b/.github/workflows/train_model.yml
@@ -33,6 +33,7 @@ jobs:
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add models/*.csv
           git commit -m 'Update model weights [skip ci]' || echo "No changes to commit"
+          git pull --rebase
           git push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- pull remote changes before pushing updated model weights

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857ff5fece88326886d298e8464b630