### PR TITLE
Add .gitattributes to exclude ipynb files from linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ignore Jupyter notebooks in GitHub language stats to reflect actual codebase languages
+*.ipynb linguist-vendored


### PR DESCRIPTION
## Summary
- ignore Jupyter notebooks in GitHub language statistics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ff405347c832680fde11f0a0f771c