### PR TITLE
Add markdown wiki

### DIFF
--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -1,0 +1,10 @@
+# Architecture
+
+The pipeline consists of several components working together:
+
+1. **Rust data tools** in `rust_fetch/` fetch raw Bitcoin data and convert it to Parquet.
+2. **Python training code** in `python_train/` trains a linear regression model on the processed dataset.
+3. **React client** in `react_client/` visualizes price history and predictions.
+4. **GitHub Actions workflows** orchestrate fetching, training and deployment.
+
+The folder structure is described in the [project README](../README.md#project-structure).

--- a/wiki/CI-CD.md
+++ b/wiki/CI-CD.md
@@ -1,0 +1,10 @@
+# CI/CD Workflows
+
+GitHub Actions orchestrate the pipeline:
+
+- `fetch_data.yml` builds the Rust tools and updates the dataset.
+- `train_model.yml` runs the training notebook and commits new weights.
+- `deploy_react_client.yml` deploys the React app to GitHub Pages.
+- `ml_pipeline.yml` ties everything together on a schedule or manual trigger.
+
+See the [workflows README](../.github/workflows/README.md) for local testing with `act`.

--- a/wiki/Data.md
+++ b/wiki/Data.md
@@ -1,0 +1,8 @@
+# Data Collection
+
+Data is stored under the [`data/`](../data/) directory.
+
+- **Raw** data (`raw/`) contains a JSONL file with 5‑minute Bitcoin Fear & Greed history.
+- **Processed** data (`processed/`) holds a Parquet dataset produced by the Rust tools.
+
+The workflow `.github/workflows/fetch_data.yml` builds the data fetching binaries, downloads the latest entries and commits updated files back to the repository.

--- a/wiki/Frontend.md
+++ b/wiki/Frontend.md
@@ -1,0 +1,9 @@
+# Frontend
+
+The React application in [`react_client/`](../react_client/) displays Bitcoin prices and model predictions.
+
+Useful files:
+- `src/` holds TypeScript components and hooks.
+- `public/` contains static assets.
+
+The workflow `deploy_react_client.yml` builds the app and publishes it to GitHub Pages. The latest deployment is at <https://elarsaks.github.io/gha_ml_pipeline/>.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,14 @@
+# Project Home
+
+Welcome to the **gha-ml-pipeline** wiki. This documentation explains the purpose of the project and links to sub‑pages describing each component.
+
+This repo demonstrates a full machine learning pipeline for predicting the Bitcoin Fear & Greed Index, using GitHub Actions for CI/CD. Data and models are stored directly in the repository.
+
+## Contents
+- [Architecture](Architecture.md)
+- [Data Collection](Data.md)
+- [Model Training](Training.md)
+- [Frontend](Frontend.md)
+- [CI/CD Workflows](CI-CD.md)
+
+For a quick overview see the [README](../README.md).

--- a/wiki/Training.md
+++ b/wiki/Training.md
@@ -1,0 +1,9 @@
+# Model Training
+
+The Python code under [`python_train/`](../python_train/) trains a simple linear regression model using `polars` and `scikit-learn`.
+
+- The notebook `linear_regression_training.ipynb` executes the workflow.
+- Model weights are written to the [`models/`](../models/) directory and tracked in git.
+- Tests for utility functions live in `python_train/tests/`.
+
+Training is automated by `.github/workflows/train_model.yml`, which runs the notebook in a Conda environment and commits updated weights.


### PR DESCRIPTION
## Summary
- add a `wiki/` directory with project documentation

## Testing
- `pytest -q python_train/tests/test_model_io.py`
- `cargo test --manifest-path rust_fetch/Cargo.toml`
- `CI=true npm test --silent` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_686ff58eb440832695206206b9e61f81